### PR TITLE
Have Visitors visit 128-bit integers

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -566,6 +566,30 @@ where
             .map_err(|err| track.trigger(chain, err))
     }
 
+    serde_if_integer128! {
+        fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let chain = self.chain;
+            let track = self.track;
+            self.delegate
+                .visit_i128(v)
+                .map_err(|err| track.trigger(chain, err))
+        }
+
+        fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let chain = self.chain;
+            let track = self.track;
+            self.delegate
+                .visit_u128(v)
+                .map_err(|err| track.trigger(chain, err))
+        }
+    }
+
     fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
     where
         E: de::Error,
@@ -1218,6 +1242,22 @@ where
         E: de::Error,
     {
         self.delegate.visit_u64(v)
+    }
+
+    serde_if_integer128! {
+        fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            self.delegate.visit_i128(v)
+        }
+
+        fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            self.delegate.visit_u128(v)
+        }
     }
 
     fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use serde::Deserialize;
+use serde::{serde_if_integer128, Deserialize};
 use serde_derive::Deserialize;
 use std::collections::BTreeMap as Map;
 use std::fmt::Debug;
@@ -192,4 +192,24 @@ fn test_syntax_error() {
     }"#;
 
     test::<Package>(j, "dependency.error");
+}
+
+serde_if_integer128! {
+    #[test]
+    fn test_u128() {
+        #[derive(Deserialize, Debug)]
+        struct Container {
+            n: u128,
+        }
+
+        let j = r#"{
+            "n": 130033514578017493995102500318550798591
+        }"#;
+
+        let de = &mut serde_json::Deserializer::from_str(j);
+        let container: Container =
+            serde_path_to_error::deserialize(de).expect("failed to deserialize");
+
+        assert_eq!(container.n, 130033514578017493995102500318550798591u128);
+    }
 }


### PR DESCRIPTION
Deserialization of 128-bit integers currently fails with `invalid type: u128, expected u128` due to the `Visitor` implementations in this crate not defining `visit_i128`/`visit_u128`. This PR corrects the issue and adds a corresponding test.