### PR TITLE
Implement is_human_readable() in deserializer

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -454,6 +454,10 @@ where
             .deserialize_identifier(Wrap::new(visitor, &chain, track))
             .map_err(|err| track.trigger(&chain, err))
     }
+
+    fn is_human_readable(&self) -> bool {
+        self.de.is_human_readable()
+    }
 }
 
 // Forwarding impl to preserve context.


### PR DESCRIPTION
The distinction is needed e.g. in [oid] to tell PEM and DER inputs apart.

[oid]: https://github.com/UnnecessaryEngineering/oid/blob/cdf1c94b8f736edbed3dae1d061d407ca1eeb2ca/src/lib.rs#L349