### PR TITLE
Fix message duplication between error Display and source()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,9 @@ impl<E: Display> Display for Error<E> {
     }
 }
 
-impl<E: StdError + 'static> StdError for Error<E> {
+impl<E: StdError> StdError for Error<E> {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(self.inner())
+        self.inner().source()
     }
 }
 


### PR DESCRIPTION
Example:

```rust
use serde::Deserialize;

#[derive(Deserialize)]
pub struct Struct {
    pub x: i32,
}

fn main() -> anyhow::Result<()> {
    let j = "{\"x\":true}";
    let mut de = serde_json::Deserializer::from_str(j);
    let _: Struct = serde_path_to_error::deserialize(&mut de)?;
    Ok(())
}
```

Previously this would print:

```console
Error: x: invalid type: boolean `true`, expected i32 at line 1 column 9

Caused by:
    invalid type: boolean `true`, expected i32 at line 1 column 9
```

In general, `std::error::Error` impls are not supposed to duplicate the same content between their `Display` and `source()` implementation.