### PR TITLE
Implement extra iterator traits for `Segments`

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -63,6 +63,12 @@ impl<'a> DoubleEndedIterator for Segments<'a> {
     }
 }
 
+impl<'a> ExactSizeIterator for Segments<'a> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
 impl Display for Path {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         if self.segments.is_empty() {

--- a/src/path.rs
+++ b/src/path.rs
@@ -51,6 +51,10 @@ impl<'a> Iterator for Segments<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl Display for Path {

--- a/src/path.rs
+++ b/src/path.rs
@@ -57,6 +57,12 @@ impl<'a> Iterator for Segments<'a> {
     }
 }
 
+impl<'a> DoubleEndedIterator for Segments<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+    }
+}
+
 impl Display for Path {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         if self.segments.is_empty() {


### PR DESCRIPTION
`Segments` is a wrapper around `std::slice::Iter` so it would be nice to have some of the extra iterator traits exposed. This PR adds impls of `DoubleEndedIterator`, `ExactSizeIterator`, and `Iterator::size_hint`.