### PR TITLE
Raise required compiler to rust 1.56

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.11" # remember to update html_root_url
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 categories = ["encoding"]
 description = "Path to the element that failed to deserialize"
-edition = "2018"
+edition = "2021"
 keywords = ["serde", "serialization"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/path-to-error"
-rust-version = "1.31"
+rust-version = "1.56"
 
 [dependencies]
 serde = "1.0"

--- a/src/path.rs
+++ b/src/path.rs
@@ -150,9 +150,6 @@ impl Path {
 
 impl Segment {
     fn is_unknown(&self) -> bool {
-        match self {
-            Segment::Unknown => true,
-            _ => false,
-        }
+        matches!(self, Segment::Unknown)
     }
 }


### PR DESCRIPTION
We haven't been testing against 1.31 since a94dea58c5e7feb06db3bc51e35377bc7ee681c9, because serde_derive no longer supports it.