### PR TITLE
Raise required compiler to Rust 1.61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.56.0]
+        rust: [nightly, beta, stable, 1.61.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 keywords = ["serde", "serialization"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/path-to-error"
-rust-version = "1.56"
+rust-version = "1.61"
 
 [dependencies]
 itoa = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,8 @@
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
     clippy::needless_lifetimes,
-    clippy::new_without_default
+    clippy::new_without_default,
+    clippy::uninlined_format_args
 )]
 #![allow(unknown_lints, mismatched_lifetime_syntaxes)]
 


### PR DESCRIPTION
Unblocks https://github.com/dtolnay/path-to-error/pull/35.